### PR TITLE
Add temperature tracking (MOS and rotor) to motor state

### DIFF
--- a/src/openarm_driver/driver.py
+++ b/src/openarm_driver/driver.py
@@ -169,7 +169,7 @@ class SingleArmDriver:
         """Fetch the MOS temperature for each motor."""
         return self.fetch_state(refresh=refresh)["tmos"]
 
-    def fetch_rotor_temp(self, refresh=True) -> np.ndarray:
+    def fetch_rotor_temperature(self, refresh=True) -> np.ndarray:
         """Fetch the rotor temperature for each motor."""
         return self.fetch_state(refresh=refresh)["trotor"]
 

--- a/src/openarm_driver/driver.py
+++ b/src/openarm_driver/driver.py
@@ -132,14 +132,17 @@ class SingleArmDriver:
         """Update the state."""
         self.openarm.recv_all(timeout_us)
         motor_values = (
-            (m.get_position(), m.get_velocity(), m.get_torque())
+            (m.get_position(), m.get_velocity(), m.get_torque(),
+             m.get_state_tmos(), m.get_state_trotor())
             for m in self._iter_motors()
         )
-        qpos, qvel, qtau = zip(*motor_values)
+        qpos, qvel, qtau, tmos, trotor = zip(*motor_values)
         self.latest_state = {
             "qpos": np.array(qpos, dtype=float) - self.joint_offsets,
             "qvel": np.array(qvel, dtype=float),
             "qtorque": np.array(qtau, dtype=float),
+            "tmos": np.array(tmos, dtype=int),
+            "trotor": np.array(trotor, dtype=int),
         }
 
     def fetch_state(self, refresh=True) -> dict[str, np.ndarray]:
@@ -161,6 +164,14 @@ class SingleArmDriver:
     def fetch_torque(self, refresh=True) -> np.ndarray:
         """Fetch the torque."""
         return self.fetch_state(refresh=refresh)["qtorque"]
+
+    def fetch_mos_temp(self, refresh=True) -> np.ndarray:
+        """Fetch the MOS temperature for each motor."""
+        return self.fetch_state(refresh=refresh)["tmos"]
+
+    def fetch_rotor_temp(self, refresh=True) -> np.ndarray:
+        """Fetch the rotor temperature for each motor."""
+        return self.fetch_state(refresh=refresh)["trotor"]
 
     def send_position(self, position: ArrayLike):
         """Move the arm by sending the position."""

--- a/src/openarm_driver/driver.py
+++ b/src/openarm_driver/driver.py
@@ -165,7 +165,7 @@ class SingleArmDriver:
         """Fetch the torque."""
         return self.fetch_state(refresh=refresh)["qtorque"]
 
-    def fetch_mos_temp(self, refresh=True) -> np.ndarray:
+    def fetch_mos_temperature(self, refresh=True) -> np.ndarray:
         """Fetch the MOS temperature for each motor."""
         return self.fetch_state(refresh=refresh)["tmos"]
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -22,6 +22,8 @@ class MotorStub:
         self.position = 0.5
         self.velocity = 0.0
         self.torque = 0.0
+        self.tmos = 25
+        self.trotor = 30
 
     def get_position(self):
         return self.position
@@ -31,6 +33,12 @@ class MotorStub:
 
     def get_torque(self):
         return self.torque
+
+    def get_state_tmos(self):
+        return self.tmos
+
+    def get_state_trotor(self):
+        return self.trotor
 
 
 class CanMock:
@@ -93,6 +101,22 @@ def test_fetch_torque(can_mock):
     driver = SingleArmDriver("right_arm")
     driver.fetch_torque(refresh=True)
     driver.fetch_torque(refresh=False)
+
+
+def test_fetch_mos_temp(can_mock):
+    driver = SingleArmDriver("right_arm")
+    temps = driver.fetch_mos_temp(refresh=True)
+    assert len(temps) == 8
+    assert all(t == 25 for t in temps)
+    driver.fetch_mos_temp(refresh=False)
+
+
+def test_fetch_rotor_temp(can_mock):
+    driver = SingleArmDriver("right_arm")
+    temps = driver.fetch_rotor_temp(refresh=True)
+    assert len(temps) == 8
+    assert all(t == 30 for t in temps)
+    driver.fetch_rotor_temp(refresh=False)
 
 
 def test_fetch_state(can_mock):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -103,14 +103,14 @@ def test_fetch_torque(can_mock):
     driver.fetch_torque(refresh=False)
 
 
-def test_fetch_mos_temp(can_mock):
+def test_fetch_mos_temperature(can_mock):
     driver = SingleArmDriver("right_arm")
     temps = driver.fetch_mos_temperature(refresh=True)
     assert temps.tolist() == [25] * 8
     driver.fetch_mos_temperature(refresh=False)
 
 
-def test_fetch_rotor_temp(can_mock):
+def test_fetch_rotor_temperature(can_mock):
     driver = SingleArmDriver("right_arm")
     temps = driver.fetch_rotor_temperature(refresh=True)
     assert temps.tolist() == [30] * 8

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -105,17 +105,16 @@ def test_fetch_torque(can_mock):
 
 def test_fetch_mos_temp(can_mock):
     driver = SingleArmDriver("right_arm")
-    temps = driver.fetch_mos_temp(refresh=True)
-    assert temps == [25] * 8
-    driver.fetch_mos_temp(refresh=False)
+    temps = driver.fetch_mos_temperature(refresh=True)
+    assert temps.tolist() == [25] * 8
+    driver.fetch_mos_temperature(refresh=False)
 
 
 def test_fetch_rotor_temp(can_mock):
     driver = SingleArmDriver("right_arm")
-    temps = driver.fetch_rotor_temp(refresh=True)
-    assert len(temps) == 8
-    assert all(t == 30 for t in temps)
-    driver.fetch_rotor_temp(refresh=False)
+    temps = driver.fetch_rotor_temperature(refresh=True)
+    assert temps.tolist() == [30] * 8
+    driver.fetch_rotor_temperature(refresh=False)
 
 
 def test_fetch_state(can_mock):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -106,8 +106,7 @@ def test_fetch_torque(can_mock):
 def test_fetch_mos_temp(can_mock):
     driver = SingleArmDriver("right_arm")
     temps = driver.fetch_mos_temp(refresh=True)
-    assert len(temps) == 8
-    assert all(t == 25 for t in temps)
+    assert temps == [25] * 8
     driver.fetch_mos_temp(refresh=False)
 
 


### PR DESCRIPTION
This PR adds per-motor temperature readings to the driver's state. Each motor now reports both its MOSFET (tmos) and rotor (trotor) temperatures, enabling thermal monitoring during operation.

Changes:
update_state() now reads get_state_tmos() and get_state_trotor() from each motor and stores them in latest_state as tmos / trotor arrays (dtype int).
Added two convenience accessors:
fetch_mos_temperature(refresh=True) — MOS temperature per motor
fetch_rotor_temperature(refresh=True) — rotor temperature per motor
Extended the test MotorStub in tests/test_driver.py with temperature getters and added test_fetch_mos_temperature / test_fetch_rotor_temperature.
