### PR TITLE
Add joint velocity command limiting

### DIFF
--- a/src/openarm_driver/config.py
+++ b/src/openarm_driver/config.py
@@ -74,6 +74,10 @@ class Config:
         """Get joint delta position limits."""
         return self._config["joint_delta_position_limits"]
 
+    def get_joint_velocity_limits(self) -> list[float] | None:
+        """Get normal per-joint command velocity limits in rad/s."""
+        return self._config.get("joint_velocity_limits")
+
     def get_can_interface(self, arm_side: str) -> str:
         """Get can interface string."""
         return self._config["can_interface"][arm_side]

--- a/src/openarm_driver/configs/openarm_cell.yaml
+++ b/src/openarm_driver/configs/openarm_cell.yaml
@@ -40,8 +40,19 @@ joint_offsets:
   right_arm: [0.0, -0.506145, 1.570796, -1.745329, 0.0, 0.331612, -1.570796, 0.0]
   left_arm: [0.0, 0.506145, -1.570796, -1.745329, 0.0, -0.331612, 1.570796, 0.0]
 
-# Joint delta position limits (rad/s).
+# Maximum accepted single-command position jump (rad).
 joint_delta_position_limits:
+  - 1.8 # J0
+  - 1.8 # J1
+  - 3.3 # J2
+  - 2.3 # J3
+  - 3.5 # J4
+  - 3.5 # J5
+  - 3.5 # J6
+  - 3.5 # J7
+
+# Normal per-joint command velocity limits (rad/s).
+joint_velocity_limits:
   - 1.8 # J0
   - 1.8 # J1
   - 3.3 # J2

--- a/src/openarm_driver/configs/openarm_cell_higher_pd.yaml
+++ b/src/openarm_driver/configs/openarm_cell_higher_pd.yaml
@@ -40,8 +40,19 @@ joint_offsets:
   right_arm: [0.0, -0.506145, 1.570796, -1.745329, 0.0, 0.331612, -1.570796, 0.0]
   left_arm: [0.0, 0.506145, -1.570796, -1.745329, 0.0, -0.331612, 1.570796, 0.0]
 
-# Joint delta position limits (rad/s).
+# Maximum accepted single-command position jump (rad).
 joint_delta_position_limits:
+  - 1.8 # J0
+  - 1.8 # J1
+  - 3.3 # J2
+  - 2.3 # J3
+  - 3.5 # J4
+  - 3.5 # J5
+  - 3.5 # J6
+  - 3.5 # J7
+
+# Normal per-joint command velocity limits (rad/s).
+joint_velocity_limits:
   - 1.8 # J0
   - 1.8 # J1
   - 3.3 # J2

--- a/src/openarm_driver/driver.py
+++ b/src/openarm_driver/driver.py
@@ -30,6 +30,9 @@ from .safety import (
 )
 
 
+MAX_COMMAND_DT_S = 0.1
+
+
 def _create_default_checker(arm_side: str, config: Config) -> CompositeChecker:
     """Create basic checker with joint limits."""
     joint_limits = config.get_joint_limits(arm_side)
@@ -185,8 +188,10 @@ class SingleArmDriver:
     def send_position(self, position: ArrayLike):
         """Move the arm by sending the position."""
         command_time_s = time.monotonic()
+        elapsed_s = max(command_time_s - self.last_command_time_s, 0.0)
+        dt_s = min(elapsed_s, MAX_COMMAND_DT_S)
         checked_result = self.safety_checker.check(
-            position, driver=self, command_time_s=command_time_s
+            position, driver=self, dt_s=dt_s
         )
         if not checked_result.is_safe:
             if checked_result.force_stop:

--- a/src/openarm_driver/driver.py
+++ b/src/openarm_driver/driver.py
@@ -26,6 +26,7 @@ from .base_safety import Checker, CompositeChecker
 from .safety import (
     JointPosChecker,
     JointDeltaPosChecker,
+    JointVelocityChecker,
 )
 
 
@@ -33,12 +34,14 @@ def _create_default_checker(arm_side: str, config: Config) -> CompositeChecker:
     """Create basic checker with joint limits."""
     joint_limits = config.get_joint_limits(arm_side)
     delta_limits = config.get_joint_delta_position_limits()
-    return CompositeChecker(
-        [
-            JointPosChecker(joint_limits),
-            JointDeltaPosChecker(delta_limits),
-        ]
-    )
+    checkers = [
+        JointPosChecker(joint_limits),
+        JointDeltaPosChecker(delta_limits),
+    ]
+    velocity_limits = config.get_joint_velocity_limits()
+    if velocity_limits is not None:
+        checkers.append(JointVelocityChecker(velocity_limits))
+    return CompositeChecker(checkers)
 
 
 class SingleArmDriver:
@@ -109,6 +112,7 @@ class SingleArmDriver:
         for _ in range(20):
             time.sleep(0.01)
             self.last_command = self.fetch_position(refresh=True)
+        self.last_command_time_s = time.monotonic()
 
     def start(self):
         """Start the arm."""
@@ -180,7 +184,10 @@ class SingleArmDriver:
 
     def send_position(self, position: ArrayLike):
         """Move the arm by sending the position."""
-        checked_result = self.safety_checker.check(position, driver=self)
+        command_time_s = time.monotonic()
+        checked_result = self.safety_checker.check(
+            position, driver=self, command_time_s=command_time_s
+        )
         if not checked_result.is_safe:
             if checked_result.force_stop:
                 raise RuntimeError(checked_result.message)
@@ -189,6 +196,7 @@ class SingleArmDriver:
 
         target_pos = np.asarray(position, dtype=float)
         self.last_command = target_pos
+        self.last_command_time_s = command_time_s
 
         self.openarm.get_arm().mit_control_all(
             [

--- a/src/openarm_driver/safety.py
+++ b/src/openarm_driver/safety.py
@@ -20,10 +20,6 @@ from numpy.typing import ArrayLike
 from .base_safety import Checker, CheckResult
 
 
-DEFAULT_COMMAND_DT_S = 1.0 / 250.0
-MAX_COMMAND_DT_S = 0.1
-
-
 class JointPosChecker(Checker):
     """Check that joint positions are within limits."""
 
@@ -114,42 +110,21 @@ class JointDeltaPosChecker(Checker):
 class JointVelocityChecker(Checker):
     """Limit per-joint command velocity using elapsed command time."""
 
-    def __init__(
-        self,
-        velocity_limits: ArrayLike,
-        default_dt_s: float = DEFAULT_COMMAND_DT_S,
-        max_dt_s: float = MAX_COMMAND_DT_S,
-    ):
+    def __init__(self, velocity_limits: ArrayLike):
         """Initialize joint velocity checker.
 
         Args:
             velocity_limits: Maximum command velocity in rad/s for each joint.
-            default_dt_s: Fallback command period when timing is unavailable.
-            max_dt_s: Maximum elapsed time credited to one command.
 
         """
         self.velocity_limits = np.asarray(velocity_limits, dtype=float)
-        self.default_dt_s = float(default_dt_s)
-        self.max_dt_s = float(max_dt_s)
         if np.any(self.velocity_limits <= 0.0):
             raise ValueError("Joint velocity limits must be positive.")
-        if self.default_dt_s <= 0.0:
-            raise ValueError("Default command period must be positive.")
-        if self.max_dt_s < self.default_dt_s:
-            raise ValueError(
-                "Maximum command period must be at least the default period."
-            )
 
     def check(self, joint_positions: ArrayLike, **kwargs) -> CheckResult:
         """Clamp a command to the motion allowed since the last command."""
-        driver = kwargs.get("driver")
-        if driver is None or not hasattr(driver, "last_command"):
-            return CheckResult(
-                is_safe=True,
-                message="No previous command to compare against.",
-                check_type="joint_velocity",
-            )
-
+        driver = kwargs["driver"]
+        dt_s = float(kwargs["dt_s"])
         positions = np.asarray(joint_positions, dtype=float)
         previous = np.asarray(driver.last_command, dtype=float)
         if (
@@ -160,17 +135,6 @@ class JointVelocityChecker(Checker):
                 "Joint positions, previous command, and velocity limits "
                 "must have the same shape."
             )
-
-        command_time_s = kwargs.get("command_time_s")
-        previous_time_s = getattr(driver, "last_command_time_s", None)
-        if command_time_s is None or previous_time_s is None:
-            dt_s = self.default_dt_s
-        else:
-            elapsed_s = float(command_time_s) - float(previous_time_s)
-            if not np.isfinite(elapsed_s) or elapsed_s <= 0.0:
-                dt_s = self.default_dt_s
-            else:
-                dt_s = min(elapsed_s, self.max_dt_s)
 
         delta = positions - previous
         max_delta = self.velocity_limits * dt_s

--- a/src/openarm_driver/safety.py
+++ b/src/openarm_driver/safety.py
@@ -20,6 +20,10 @@ from numpy.typing import ArrayLike
 from .base_safety import Checker, CheckResult
 
 
+DEFAULT_COMMAND_DT_S = 1.0 / 250.0
+MAX_COMMAND_DT_S = 0.1
+
+
 class JointPosChecker(Checker):
     """Check that joint positions are within limits."""
 
@@ -60,7 +64,7 @@ class JointPosChecker(Checker):
 
 
 class JointDeltaPosChecker(Checker):
-    """Check that joint position changes don't exceed velocity limits."""
+    """Check that a single joint command does not contain an abnormal jump."""
 
     def __init__(self, delta_limits: ArrayLike):
         """Initialize delta position checker.
@@ -104,4 +108,90 @@ class JointDeltaPosChecker(Checker):
             is_safe=True,
             message="All joint deltas within limits.",
             check_type="joint_delta",
+        )
+
+
+class JointVelocityChecker(Checker):
+    """Limit per-joint command velocity using elapsed command time."""
+
+    def __init__(
+        self,
+        velocity_limits: ArrayLike,
+        default_dt_s: float = DEFAULT_COMMAND_DT_S,
+        max_dt_s: float = MAX_COMMAND_DT_S,
+    ):
+        """Initialize joint velocity checker.
+
+        Args:
+            velocity_limits: Maximum command velocity in rad/s for each joint.
+            default_dt_s: Fallback command period when timing is unavailable.
+            max_dt_s: Maximum elapsed time credited to one command.
+
+        """
+        self.velocity_limits = np.asarray(velocity_limits, dtype=float)
+        self.default_dt_s = float(default_dt_s)
+        self.max_dt_s = float(max_dt_s)
+        if np.any(self.velocity_limits <= 0.0):
+            raise ValueError("Joint velocity limits must be positive.")
+        if self.default_dt_s <= 0.0:
+            raise ValueError("Default command period must be positive.")
+        if self.max_dt_s < self.default_dt_s:
+            raise ValueError(
+                "Maximum command period must be at least the default period."
+            )
+
+    def check(self, joint_positions: ArrayLike, **kwargs) -> CheckResult:
+        """Clamp a command to the motion allowed since the last command."""
+        driver = kwargs.get("driver")
+        if driver is None or not hasattr(driver, "last_command"):
+            return CheckResult(
+                is_safe=True,
+                message="No previous command to compare against.",
+                check_type="joint_velocity",
+            )
+
+        positions = np.asarray(joint_positions, dtype=float)
+        previous = np.asarray(driver.last_command, dtype=float)
+        if (
+            positions.shape != previous.shape
+            or positions.shape != self.velocity_limits.shape
+        ):
+            raise ValueError(
+                "Joint positions, previous command, and velocity limits "
+                "must have the same shape."
+            )
+
+        command_time_s = kwargs.get("command_time_s")
+        previous_time_s = getattr(driver, "last_command_time_s", None)
+        if command_time_s is None or previous_time_s is None:
+            dt_s = self.default_dt_s
+        else:
+            elapsed_s = float(command_time_s) - float(previous_time_s)
+            if not np.isfinite(elapsed_s) or elapsed_s <= 0.0:
+                dt_s = self.default_dt_s
+            else:
+                dt_s = min(elapsed_s, self.max_dt_s)
+
+        delta = positions - previous
+        max_delta = self.velocity_limits * dt_s
+        velocity_limited = previous + np.clip(delta, -max_delta, max_delta)
+        violations = np.abs(delta) > max_delta
+        if np.any(violations):
+            violated_joints = np.where(violations)[0].tolist()
+            return CheckResult(
+                is_safe=False,
+                force_stop=False,
+                fixed_joint_positions=velocity_limited,
+                message=f"Joint velocity limited at joints: {violated_joints}",
+                check_type="joint_velocity",
+                details={
+                    "violated_joints": violated_joints,
+                    "dt_s": dt_s,
+                },
+            )
+
+        return CheckResult(
+            is_safe=True,
+            message="All joint command velocities within limits.",
+            check_type="joint_velocity",
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -165,3 +165,9 @@ def test_get_stop_config():
     config = get_default_config()
     stop_config = config.get_stop_config()
     assert stop_config["moves"][0]["name"] == "initial"
+
+
+def test_get_joint_velocity_limits():
+    config = get_default_config()
+    velocity_limits = config.get_joint_velocity_limits()
+    assert velocity_limits == [1.8, 1.8, 3.3, 2.3, 3.5, 3.5, 3.5, 3.5]

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import pytest
 
+from openarm_driver.base_safety import CheckResult
 from openarm_driver.driver import SingleArmDriver
 from openarm_driver.safety import JointVelocityChecker
 
@@ -153,22 +154,38 @@ def test_delta_pos_limit(can_mock, config_mock_hard_delta_limit):
 
 
 @pytest.mark.parametrize(
-    ("command_time_s", "expected_delta"),
-    [(1.05, 0.05), (2.0, 0.1)],
+    ("dt_s", "expected_delta"),
+    [(0.05, 0.05), (0.1, 0.1)],
 )
-def test_velocity_limit(command_time_s, expected_delta):
+def test_velocity_limit(dt_s, expected_delta):
     checker = JointVelocityChecker([1.0] * 8)
-    driver = SimpleNamespace(
-        last_command=np.zeros(8),
-        last_command_time_s=1.0,
-    )
+    driver = SimpleNamespace(last_command=np.zeros(8))
     result = checker.check(
         [0.5] * 8,
         driver=driver,
-        command_time_s=command_time_s,
+        dt_s=dt_s,
     )
 
     assert not result.is_safe
     assert not result.force_stop
     assert result.check_type == "joint_velocity"
     np.testing.assert_allclose(result.fixed_joint_positions, [expected_delta] * 8)
+
+
+def test_driver_caps_command_dt(can_mock, monkeypatch):
+    command_times = iter([1.0, 2.0])
+    monkeypatch.setattr(
+        "openarm_driver.driver.time.monotonic",
+        lambda: next(command_times),
+    )
+
+    class RecordingChecker:
+        def check(self, joint_positions, **kwargs):
+            self.dt_s = kwargs["dt_s"]
+            return CheckResult(is_safe=True)
+
+    checker = RecordingChecker()
+    driver = SingleArmDriver("right_arm", safety_checker=checker)
+    driver.send_position(driver.last_command)
+
+    assert checker.dt_s == pytest.approx(0.1)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
+import numpy as np
+
 import pytest
 
 from openarm_driver.driver import SingleArmDriver
+from openarm_driver.safety import JointVelocityChecker
 
 
 class MotorStub:
@@ -145,3 +150,25 @@ def test_delta_pos_limit(can_mock, config_mock_hard_delta_limit):
     driver = SingleArmDriver("right_arm")
     with pytest.raises(RuntimeError):
         driver.send_position([3.0] * 8)
+
+
+@pytest.mark.parametrize(
+    ("command_time_s", "expected_delta"),
+    [(1.05, 0.05), (2.0, 0.1)],
+)
+def test_velocity_limit(command_time_s, expected_delta):
+    checker = JointVelocityChecker([1.0] * 8)
+    driver = SimpleNamespace(
+        last_command=np.zeros(8),
+        last_command_time_s=1.0,
+    )
+    result = checker.check(
+        [0.5] * 8,
+        driver=driver,
+        command_time_s=command_time_s,
+    )
+
+    assert not result.is_safe
+    assert not result.force_stop
+    assert result.check_type == "joint_velocity"
+    np.testing.assert_allclose(result.fixed_joint_positions, [expected_delta] * 8)


### PR DESCRIPTION
## Summary

- keep the existing per-command delta checker as a hard abnormal-jump guard
- add optional per-joint velocity limits with command clipping
- compute elapsed command time in the driver and cap credited time at 0.1 seconds
- keep the velocity checker focused on comparing and correcting joint deltas

## Why

The existing `joint_delta_position_limits` values are single-command jump thresholds, not rates. Normal command velocity limiting needs a separate configuration entry and real elapsed time, while stale gaps must not permit a large catch-up step.

## Validation

- `ruff check src tests`
- `pytest -q` (37 passed)
