### PR TITLE
Add joint command velocity limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,18 @@ finally:
 
 ## Config
 
-Please refer to [src/openarm_driver/config.yaml](src/openarm_driver/config.yaml), the default configuration.
+Please refer to the [default configuration](src/openarm_driver/configs/openarm_cell.yaml).
+
+The default safety checks run in this order:
+
+1. `JointPosChecker` clips commands to joint position limits.
+2. `JointDeltaPosChecker` rejects excessive single-command jumps.
+3. `JointVelocityChecker` limits the remaining command using the elapsed time.
+
+`joint_velocity_limits` is specified in rad/s. `send_position()` measures the
+elapsed command time automatically, so callers do not need to provide the node
+control frequency. Custom configurations may omit this field to disable command
+velocity limiting.
 
 ## Development
 

--- a/src/openarm_driver/__init__.py
+++ b/src/openarm_driver/__init__.py
@@ -37,4 +37,5 @@ from .base_safety import (
 from .safety import (
     JointPosChecker as JointPosChecker,
     JointDeltaPosChecker as JointDeltaPosChecker,
+    JointVelocityChecker as JointVelocityChecker,
 )

--- a/src/openarm_driver/config.py
+++ b/src/openarm_driver/config.py
@@ -74,6 +74,10 @@ class Config:
         """Get joint delta position limits."""
         return self._config["joint_delta_position_limits"]
 
+    def get_joint_velocity_limits(self) -> list[float] | None:
+        """Get per-joint command velocity limits in rad/s."""
+        return self._config.get("joint_velocity_limits")
+
     def get_can_interface(self, arm_side: str) -> str:
         """Get can interface string."""
         return self._config["can_interface"][arm_side]

--- a/src/openarm_driver/configs/openarm_cell.yaml
+++ b/src/openarm_driver/configs/openarm_cell.yaml
@@ -40,16 +40,27 @@ joint_offsets:
   right_arm: [0.0, -0.506145, 1.570796, -1.745329, 0.0, 0.331612, -1.570796, 0.0]
   left_arm: [0.0, 0.506145, -1.570796, -1.745329, 0.0, -0.331612, 1.570796, 0.0]
 
-# Joint delta position limits (rad/s).
+# Maximum accepted single-command position jump (rad).
 joint_delta_position_limits:
-  - 1.8 # J0
-  - 1.8 # J1
-  - 3.3 # J2
-  - 2.3 # J3
-  - 3.5 # J4
-  - 3.5 # J5
-  - 3.5 # J6
-  - 3.5 # J7
+  - 1.0 # J1
+  - 1.0 # J2
+  - 1.0 # J3
+  - 1.5 # J4
+  - 1.5 # J5
+  - 1.5 # J6
+  - 1.5 # J7
+  - 3.14 # J8
+
+# Per-joint command velocity limits (rad/s).
+joint_velocity_limits:
+  - 2.0 # J1
+  - 2.0 # J2
+  - 3.3 # J3
+  - 3.3 # J4
+  - 6.3 # J5
+  - 6.3 # J6
+  - 6.3 # J7
+  - 20.0 # J8 (gripper)
 
 # CAN interface
 can_interface:

--- a/src/openarm_driver/configs/openarm_cell_higher_pd.yaml
+++ b/src/openarm_driver/configs/openarm_cell_higher_pd.yaml
@@ -40,16 +40,27 @@ joint_offsets:
   right_arm: [0.0, -0.506145, 1.570796, -1.745329, 0.0, 0.331612, -1.570796, 0.0]
   left_arm: [0.0, 0.506145, -1.570796, -1.745329, 0.0, -0.331612, 1.570796, 0.0]
 
-# Joint delta position limits (rad/s).
+# Maximum accepted single-command position jump (rad).
 joint_delta_position_limits:
-  - 1.8 # J0
-  - 1.8 # J1
-  - 3.3 # J2
-  - 2.3 # J3
-  - 3.5 # J4
-  - 3.5 # J5
-  - 3.5 # J6
-  - 3.5 # J7
+  - 1.0 # J1
+  - 1.0 # J2
+  - 1.0 # J3
+  - 1.5 # J4
+  - 1.5 # J5
+  - 1.5 # J6
+  - 1.5 # J7
+  - 3.14 # J8
+
+# Per-joint command velocity limits (rad/s).
+joint_velocity_limits:
+  - 2.0 # J1
+  - 2.0 # J2
+  - 3.3 # J3
+  - 3.3 # J4
+  - 6.3 # J5
+  - 6.3 # J6
+  - 6.3 # J7
+  - 20.0 # J8 (gripper)
 
 # CAN interface
 can_interface:

--- a/src/openarm_driver/driver.py
+++ b/src/openarm_driver/driver.py
@@ -26,19 +26,25 @@ from .base_safety import Checker, CompositeChecker
 from .safety import (
     JointPosChecker,
     JointDeltaPosChecker,
+    JointVelocityChecker,
 )
+
+
+MAX_COMMAND_DT_S = 0.1
 
 
 def _create_default_checker(arm_side: str, config: Config) -> CompositeChecker:
     """Create basic checker with joint limits."""
     joint_limits = config.get_joint_limits(arm_side)
     delta_limits = config.get_joint_delta_position_limits()
-    return CompositeChecker(
-        [
-            JointPosChecker(joint_limits),
-            JointDeltaPosChecker(delta_limits),
-        ]
-    )
+    checkers = [
+        JointPosChecker(joint_limits),
+        JointDeltaPosChecker(delta_limits),
+    ]
+    velocity_limits = config.get_joint_velocity_limits()
+    if velocity_limits is not None:
+        checkers.append(JointVelocityChecker(velocity_limits))
+    return CompositeChecker(checkers)
 
 
 class SingleArmDriver:
@@ -98,7 +104,7 @@ class SingleArmDriver:
         self.kps = self.config.get_default_kps() if kps is None else np.array(kps)
         self.kds = self.config.get_default_kds() if kds is None else np.array(kds)
 
-        # If no checker provided, create basic joint limit checker only
+        # If no checker is provided, use the default safety checks.
         self.safety_checker = (
             _create_default_checker(arm_side, self.config)
             if safety_checker is None
@@ -109,6 +115,7 @@ class SingleArmDriver:
         for _ in range(20):
             time.sleep(0.01)
             self.last_command = self.fetch_position(refresh=True)
+        self.last_command_time_s = time.monotonic()
 
     def start(self):
         """Start the arm."""
@@ -180,7 +187,14 @@ class SingleArmDriver:
 
     def send_position(self, position: ArrayLike):
         """Move the arm by sending the position."""
-        checked_result = self.safety_checker.check(position, driver=self)
+        command_time_s = time.monotonic()
+        elapsed_s = max(command_time_s - self.last_command_time_s, 0.0)
+        dt_s = min(elapsed_s, MAX_COMMAND_DT_S)
+        checked_result = self.safety_checker.check(
+            position,
+            driver=self,
+            dt_s=dt_s,
+        )
         if not checked_result.is_safe:
             if checked_result.force_stop:
                 raise RuntimeError(checked_result.message)
@@ -189,6 +203,7 @@ class SingleArmDriver:
 
         target_pos = np.asarray(position, dtype=float)
         self.last_command = target_pos
+        self.last_command_time_s = command_time_s
 
         self.openarm.get_arm().mit_control_all(
             [

--- a/src/openarm_driver/safety.py
+++ b/src/openarm_driver/safety.py
@@ -105,3 +105,54 @@ class JointDeltaPosChecker(Checker):
             message="All joint deltas within limits.",
             check_type="joint_delta",
         )
+
+
+class JointVelocityChecker(Checker):
+    """Limit per-joint command velocity using elapsed command time."""
+
+    def __init__(self, velocity_limits: ArrayLike):
+        """Initialize with maximum command velocities in rad/s."""
+        self.velocity_limits = np.asarray(velocity_limits, dtype=float)
+        if (
+            self.velocity_limits.ndim != 1
+            or not np.all(np.isfinite(self.velocity_limits))
+            or np.any(self.velocity_limits <= 0.0)
+        ):
+            raise ValueError("Joint velocity limits must be finite and positive.")
+
+    def check(self, joint_positions: ArrayLike, **kwargs) -> CheckResult:
+        """Clamp a command to the motion allowed since the last command."""
+        dt_s = float(kwargs["dt_s"])
+        if not np.isfinite(dt_s) or dt_s < 0.0:
+            raise ValueError("Command period must be finite and non-negative.")
+
+        positions = np.asarray(joint_positions, dtype=float)
+        previous = np.asarray(kwargs["driver"].last_command, dtype=float)
+        if not (positions.shape == previous.shape == self.velocity_limits.shape):
+            raise ValueError(
+                "Joint positions, previous command, and velocity limits "
+                "must have the same shape."
+            )
+        if not np.all(np.isfinite(positions)) or not np.all(np.isfinite(previous)):
+            raise ValueError("Joint positions must contain only finite values.")
+
+        delta = positions - previous
+        max_delta = self.velocity_limits * dt_s
+        limited_positions = previous + np.clip(delta, -max_delta, max_delta)
+        violations = np.abs(delta) > max_delta
+        if np.any(violations):
+            violated_joints = np.where(violations)[0].tolist()
+            return CheckResult(
+                is_safe=False,
+                force_stop=False,
+                fixed_joint_positions=limited_positions,
+                message=f"Joint velocity limited at joints: {violated_joints}",
+                check_type="joint_velocity",
+                details={"violated_joints": violated_joints, "dt_s": dt_s},
+            )
+
+        return CheckResult(
+            is_safe=True,
+            message="All joint command velocities within limits.",
+            check_type="joint_velocity",
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,7 +94,7 @@ def test_get_joint_offsets():
 def test_get_joint_delta_position_limits():
     config = get_default_config()
     delta_limit = config.get_joint_delta_position_limits()
-    assert delta_limit == [1.8, 1.8, 3.3, 2.3, 3.5, 3.5, 3.5, 3.5]
+    assert delta_limit == [1.0, 1.0, 1.0, 1.5, 1.5, 1.5, 1.5, 3.14]
 
 
 def test_get_can_interface():
@@ -165,3 +165,9 @@ def test_get_stop_config():
     config = get_default_config()
     stop_config = config.get_stop_config()
     assert stop_config["moves"][0]["name"] == "initial"
+
+
+def test_get_joint_velocity_limits():
+    config = get_default_config()
+    velocity_limits = config.get_joint_velocity_limits()
+    assert velocity_limits == [2.0, 2.0, 3.3, 3.3, 6.3, 6.3, 6.3, 20.0]

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 
+from openarm_driver.base_safety import CheckResult
+from openarm_driver.config import get_default_config
 from openarm_driver.driver import SingleArmDriver
+from openarm_driver.safety import JointPosChecker, JointVelocityChecker
 
 
 class MotorStub:
@@ -125,7 +131,7 @@ def test_fetch_state(can_mock):
 
 def test_send_position(can_mock):
     driver = SingleArmDriver("right_arm")
-    driver.send_position([0.0] * 8)
+    driver.send_position(driver.last_command)
 
 
 def test_smooth_move(can_mock):
@@ -134,7 +140,9 @@ def test_smooth_move(can_mock):
 
 
 def test_pos_limit(can_mock):
-    driver = SingleArmDriver("right_arm")
+    config = get_default_config()
+    checker = JointPosChecker(config.get_joint_limits("right_arm"))
+    driver = SingleArmDriver("right_arm", safety_checker=checker)
     driver.send_position([1.0] * 8)
     driver.send_position([2.0] * 8)
     driver.send_position([3.0] * 8)
@@ -145,3 +153,64 @@ def test_delta_pos_limit(can_mock, config_mock_hard_delta_limit):
     driver = SingleArmDriver("right_arm")
     with pytest.raises(RuntimeError):
         driver.send_position([3.0] * 8)
+
+
+def test_velocity_limit():
+    checker = JointVelocityChecker([1.0, 2.0])
+    driver = SimpleNamespace(last_command=np.zeros(2))
+
+    result = checker.check([1.0, -1.0], driver=driver, dt_s=0.1)
+
+    assert not result.is_safe
+    np.testing.assert_allclose(result.fixed_joint_positions, [0.1, -0.2])
+
+
+def test_default_velocity_limit_updates_command(can_mock, monkeypatch):
+    driver = SingleArmDriver("right_arm")
+    driver.last_command = np.zeros(8)
+    driver.last_command_time_s = 1.0
+    monkeypatch.setattr(
+        "openarm_driver.driver.time.monotonic",
+        lambda: 1.01,
+    )
+
+    requested = np.full(8, 0.1)
+    limits = np.asarray(driver.config.get_joint_velocity_limits())
+    expected = np.clip(requested, -limits * 0.01, limits * 0.01)
+
+    driver.send_position(requested)
+
+    np.testing.assert_allclose(driver.last_command, expected)
+    np.testing.assert_allclose(
+        driver.latest_state["qpos"][: driver.num_mit_motors],
+        expected[: driver.num_mit_motors],
+    )
+    assert driver.last_command_time_s == pytest.approx(1.01)
+
+
+@pytest.mark.parametrize("dt_s", [np.nan, np.inf, -0.1])
+def test_velocity_limit_rejects_invalid_dt(dt_s):
+    checker = JointVelocityChecker([1.0])
+    driver = SimpleNamespace(last_command=np.zeros(1))
+
+    with pytest.raises(ValueError, match="period"):
+        checker.check([1.0], driver=driver, dt_s=dt_s)
+
+
+def test_driver_caps_command_dt(can_mock, monkeypatch):
+    command_times = iter([1.0, 2.0])
+    monkeypatch.setattr(
+        "openarm_driver.driver.time.monotonic",
+        lambda: next(command_times),
+    )
+
+    class RecordingChecker:
+        def check(self, joint_positions, **kwargs):
+            self.dt_s = kwargs["dt_s"]
+            return CheckResult(is_safe=True)
+
+    checker = RecordingChecker()
+    driver = SingleArmDriver("right_arm", safety_checker=checker)
+    driver.send_position(driver.last_command)
+
+    assert checker.dt_s == pytest.approx(0.1)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -129,9 +129,23 @@ def test_fetch_state(can_mock):
     driver.fetch_state(refresh=False)
 
 
-def test_send_position(can_mock):
+def test_send_position(can_mock, monkeypatch):
+    command_times = iter([1.0, 1.01])
+    monkeypatch.setattr(
+        "openarm_driver.driver.time.monotonic",
+        lambda: next(command_times),
+    )
     driver = SingleArmDriver("right_arm")
-    driver.send_position(driver.last_command)
+    driver.last_command = np.zeros(8)
+    requested = np.full(8, 0.01)
+
+    driver.send_position(requested)
+
+    np.testing.assert_allclose(driver.last_command, requested)
+    np.testing.assert_allclose(
+        driver.latest_state["qpos"][: driver.num_mit_motors],
+        requested[: driver.num_mit_motors],
+    )
 
 
 def test_smooth_move(can_mock):


### PR DESCRIPTION
## Summary

- Add configurable per-joint command velocity limits.
- Clamp position commands based on elapsed command time.
- Add unit and driver integration coverage.

## Testing

- Ruff checks passed
- 40 tests passed